### PR TITLE
Allow files as input to jar_jar task

### DIFF
--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -10,7 +10,7 @@ def _jar_jar_impl(ctx):
 jar_jar = rule(
     implementation = _jar_jar_impl,
     attrs = {
-        "input_jar": attr.label(single_file=True),
+        "input_jar": attr.label(allow_files=True, single_file=True),
         "rules": attr.label(allow_files=True, single_file=True),
         "_jarjar_runner": attr.label(executable=True, cfg="host", default=Label("@com_github_johnynek_bazel_jar_jar//:jarjar_runner")),
     },


### PR DESCRIPTION
If you point the current version at a `_deploy.jar`, it fails with: `file '//:main_deploy.jar' is misplaced here (expected no files).`

Allowing files seems pretty harmless, and seems to do the right thing!
